### PR TITLE
Add logging for render reason, automatically retry if 'data-server-rendered' is not present

### DIFF
--- a/renderers/renderer-puppeteer/es6/renderer.js
+++ b/renderers/renderer-puppeteer/es6/renderer.js
@@ -7,18 +7,18 @@ const waitForRender = function (options) {
   return new Promise((resolve, reject) => {
     // Render when an event fires on the document.
     if (options.renderAfterDocumentEvent) {
-      if (window['__PRERENDER_STATUS'] && window['__PRERENDER_STATUS'].__DOCUMENT_EVENT_RESOLVED) resolve()
-      document.addEventListener(options.renderAfterDocumentEvent, () => resolve())
+      if (window['__PRERENDER_STATUS'] && window['__PRERENDER_STATUS'].__DOCUMENT_EVENT_RESOLVED) resolve('Document Event Resolved')
+      document.addEventListener(options.renderAfterDocumentEvent, () => resolve('Render After document event'))
     }
 
     if (options.renderAfterTime) {
-      setTimeout(() => resolve(), options.renderAfterTime)
+      setTimeout(() => resolve('Timeout'), options.renderAfterTime)
     }
 
-    if (!options.renderAfterDocumentEvent && !options.renderAfterTime) {
-      resolve()
+    if (!options.renderAfterDocumentEvent && !options.renderAfterTime) {  
+      resolve('Resolving because no options specified')
     }
-  })
+  }).then(reasonCode => console.log('Render Reason code: ' + reasonCode));
 }
 
 class PuppeteerRenderer {
@@ -129,6 +129,10 @@ class PuppeteerRenderer {
         originalRoute: route,
         route: await page.evaluate('window.location.pathname'),
         html: await page.content()
+      };
+
+      if (!result.html.includes('data-server-rendered="true"')) {
+        throw "Page wasn't rendered properly, was missing data-server-rendered attribute";
       }
 
       if (!page.isClosed()) {

--- a/renderers/renderer-puppeteer/es6/renderer.js
+++ b/renderers/renderer-puppeteer/es6/renderer.js
@@ -19,7 +19,9 @@ const waitForRender = function (options) {
       resolve('No options specified')
     }
   })
-  .then(reasonCode => console.log('Render reason code:', reasonCode, 'Route:', document.location.pathname));
+  .then(reasonCode => {
+    console.log('Render reason code:', reasonCode, 'Route:', document.location.pathname);
+  });
 }
 
 class PuppeteerRenderer {
@@ -132,8 +134,8 @@ class PuppeteerRenderer {
         html: await page.content()
       };
 
-      if (!result.html.includes('data-server-rendered="true"')) {
-        throw "Page wasn't rendered properly, was missing data-server-rendered attribute";
+      if (!result.html.includes('data-server-rendered')) {
+        throw new Error("Page wasn't rendered properly, was missing data-server-rendered attribute");
       }
 
       if (!page.isClosed()) {

--- a/renderers/renderer-puppeteer/es6/renderer.js
+++ b/renderers/renderer-puppeteer/es6/renderer.js
@@ -7,8 +7,8 @@ const waitForRender = function (options) {
   return new Promise((resolve, reject) => {
     // Render when an event fires on the document.
     if (options.renderAfterDocumentEvent) {
-      if (window['__PRERENDER_STATUS'] && window['__PRERENDER_STATUS'].__DOCUMENT_EVENT_RESOLVED) resolve('Document Event Resolved')
-      document.addEventListener(options.renderAfterDocumentEvent, () => resolve('Render After document event'))
+      if (window['__PRERENDER_STATUS'] && window['__PRERENDER_STATUS'].__DOCUMENT_EVENT_RESOLVED) resolve('Render Event Already Resolved')
+      document.addEventListener(options.renderAfterDocumentEvent, () => resolve('Render Event Fired'))
     }
 
     if (options.renderAfterTime) {
@@ -16,9 +16,9 @@ const waitForRender = function (options) {
     }
 
     if (!options.renderAfterDocumentEvent && !options.renderAfterTime) {  
-      resolve('Resolving because no options specified')
+      resolve('No options specified')
     }
-  }).then(reasonCode => console.log('Render Reason code: ' + reasonCode));
+  }).then(reasonCode => console.log('Render reason code: ' + reasonCode));
 }
 
 class PuppeteerRenderer {

--- a/renderers/renderer-puppeteer/es6/renderer.js
+++ b/renderers/renderer-puppeteer/es6/renderer.js
@@ -18,7 +18,8 @@ const waitForRender = function (options) {
     if (!options.renderAfterDocumentEvent && !options.renderAfterTime) {  
       resolve('No options specified')
     }
-  }).then(reasonCode => console.log('Render reason code: ' + reasonCode));
+  })
+  .then(reasonCode => console.log('Render reason code:', reasonCode, 'Route:', document.location.pathname));
 }
 
 class PuppeteerRenderer {


### PR DESCRIPTION
Fixes issue where sometimes pages would prerender but weren't actually prerendered correctly

The issue:
![image](https://user-images.githubusercontent.com/77012821/179511593-65b9ee86-264d-48ac-a53b-11908811e40c.png)


What it looks like when it happens:
![image](https://user-images.githubusercontent.com/77012821/179359050-2d51ef04-bc56-4222-8e2f-8ffdfa3e9b57.png)
